### PR TITLE
Bug fix, velocities calculated in wrong reference frame

### DIFF
--- a/humor/fitting/motion_optimizer.py
+++ b/humor/fitting/motion_optimizer.py
@@ -373,7 +373,7 @@ class MotionOptimizer():
                 vel_root_orient = prior_data_dict['root_orient']
 
             self.trans_vel, self.joints_vel, self.root_orient_vel = \
-                        self.estimate_velocities(self.trans, self.root_orient, cur_body_pose, self.betas, data_fps)
+                        self.estimate_velocities(vel_trans, vel_root_orient, cur_body_pose, self.betas, data_fps)
             
             self.trans_vel = self.trans_vel[:,:1].detach()
             self.joints_vel = self.joints_vel[:,:1].detach()


### PR DESCRIPTION
The root translation and orientation are transformed with cam2prior for the calculation of the velocities, like in infer_latent_motion, but they are then never used. Hence the latent motion is applied to x_0 which has velocities that are calculated in a different reference frame to those that the latent motion was encoded using. Hence the initial rollout is worse than it should be.
The system recovers from the bug as during the rollout the velocities are estimated in the correct frame, and the x_0 velocities are optimised.
From a quick experiment I was surprised to see that this doesn't seem to make a huge difference, but I have not done any extensive testing. Attached are videos showing the initial rollout with and without the bug, for the example rgb video.

Without bug:
https://user-images.githubusercontent.com/7931321/210800380-7435dd60-be23-4d2d-a519-c5acb06f7411.mp4
With bug:
https://user-images.githubusercontent.com/7931321/210800385-e9c8fe2e-5fe7-4881-a29f-62d682604cc4.mp4